### PR TITLE
add Script, Config, Db

### DIFF
--- a/dk-dumpdb.gemspec
+++ b/dk-dumpdb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.1"])
+  gem.add_development_dependency("assert",      ["~> 2.16.1"])
   gem.add_development_dependency("much-plugin", ["~> 0.2.0"])
 
   gem.add_dependency("dk", ["~> 0.0.1"])

--- a/lib/dk-dumpdb.rb
+++ b/lib/dk-dumpdb.rb
@@ -1,1 +1,2 @@
-require "dk-dumpdb/version"
+require 'dk-dumpdb/version'
+require 'dk-dumpdb/script'

--- a/lib/dk-dumpdb/config.rb
+++ b/lib/dk-dumpdb/config.rb
@@ -1,0 +1,122 @@
+require 'dk-dumpdb/db'
+
+module Dk::Dumpdb
+
+  class Config
+
+    attr_reader :copy_dump_cmd_args, :dump_cmds, :restore_cmds
+
+    def initialize
+      @ssh       = Ssh.new('')
+      @dump_file = DumpFile.new('')
+      @source    = SourceTargetDb.new({})
+      @target    = SourceTargetDb.new({})
+
+      @copy_dump_cmd_args = CopyDumpCmdArgs.new
+
+      @dump_cmds    = CmdList.new([])
+      @restore_cmds = CmdList.new([])
+    end
+
+    def ssh(&block)
+      @ssh = Ssh.new(block) if !block.nil?
+      @ssh
+    end
+
+    def dump_file(&block)
+      @dump_file = DumpFile.new(block) if !block.nil?
+      @dump_file
+    end
+
+    def source(&block)
+      @source = SourceTargetDb.new(block) if !block.nil?
+      @source
+    end
+
+    def target(&block)
+      @target = SourceTargetDb.new(block) if !block.nil?
+      @target
+    end
+
+    def dump(&block);    @dump_cmds    << DumpCmd.new(block);    end
+    def restore(&block); @restore_cmds << RestoreCmd.new(block); end
+
+    def dump_cmd(script, &block);   DumpCmd.new(block).value(script);    end
+    def restore_cmd(script, &block) RestoreCmd.new(block).value(script); end
+
+    class Value
+
+      attr_reader :proc
+
+      def initialize(proc = nil)
+        @proc = proc.kind_of?(::Proc) ? proc : Proc.new{ proc }
+      end
+
+      def value(script)
+        script.instance_eval(&@proc)
+      end
+
+    end
+
+    class Ssh < Value; end
+
+    class DumpFile < Value; end
+
+    class SourceTargetDb < Value
+
+      def value(script)
+        hash = super
+        Db.new(script.dump_file, hash)
+      end
+
+    end
+
+    class CopyDumpCmdArgs < Value
+
+      def value(script)
+        "#{script.source_dump_file} #{script.target_dump_file}"
+      end
+
+    end
+
+    class Cmd < Value
+
+      def value(script, placeholder_vals)
+        hsub(super(script), placeholder_vals)
+      end
+
+      private
+
+      def hsub(string, hash)
+        hash.inject(string){ |new_str, (k, v)| new_str.gsub(":#{k}", v.to_s) }
+      end
+
+    end
+
+    class DumpCmd < Cmd
+
+      def value(script, placeholder_vals = {})
+        super(script, script.source_hash.merge(placeholder_vals))
+      end
+
+    end
+
+    class RestoreCmd < Cmd
+
+      def value(script, placeholder_vals = {})
+        super(script, script.target_hash.merge(placeholder_vals))
+      end
+
+    end
+
+    class CmdList < ::Array
+
+      def value(script, placeholder_vals = {})
+        self.map{ |cmd| cmd.value(script, placeholder_vals) }
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/db.rb
+++ b/lib/dk-dumpdb/db.rb
@@ -1,0 +1,69 @@
+module Dk; end
+module Dk::Dumpdb
+
+  class Db
+
+    DEFAULT_VALUE = ''.freeze
+
+    def initialize(dump_file_name = nil, values = nil)
+      dump_file_name = dump_file_name || 'dump.output'
+      @values        = dk_dumpdb_symbolize_keys(values)
+
+      [:host, :port, :user, :pw, :db, :output_root].each do |key|
+        @values[key] ||= DEFAULT_VALUE
+      end
+
+      @values[:output_dir] = dk_dumpdb_build_output_dir(
+        self.output_root,
+        self.host,
+        self.db
+      )
+      @values[:dump_file] = File.join(self.output_dir, dump_file_name)
+    end
+
+    def to_hash; @values; end
+
+    def method_missing(meth, *args, &block)
+      if @values.has_key?(meth.to_sym)
+        @values[meth.to_sym]
+      else
+        super
+      end
+    end
+
+    def respond_to?(meth)
+      @values.has_key?(meth.to_sym) || super
+    end
+
+    def ==(other_db)
+      if other_db.kind_of?(Db)
+        self.to_hash == other_db.to_hash
+      else
+        super
+      end
+    end
+
+    private
+
+    def dk_dumpdb_build_output_dir(output_root, host, database)
+      dir_name = dk_dumpdb_build_output_dir_name(host, database)
+      if output_root && !output_root.to_s.empty?
+        File.join(output_root, dir_name)
+      else
+        dir_name
+      end
+    end
+
+    def dk_dumpdb_build_output_dir_name(host, database)
+      [host, database, Time.now.to_f].map(&:to_s).reject(&:empty?).join("__")
+    end
+
+    def dk_dumpdb_symbolize_keys(values)
+      (values || {}).inject({}) do |h, (k, v)|
+        h.merge(k.to_sym => v)
+      end
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/script.rb
+++ b/lib/dk-dumpdb/script.rb
@@ -1,0 +1,61 @@
+require 'much-plugin'
+require 'dk-dumpdb/config'
+
+module Dk::Dumpdb
+
+  module Script
+    include MuchPlugin
+
+    plugin_included do
+      include InstanceMethods
+      extend ClassMethods
+
+    end
+
+    module InstanceMethods
+
+      def config
+        @config ||= Config.new.tap do |config|
+          config.instance_eval(&self.class.config || proc{})
+        end
+      end
+
+      def ssh;       @ssh       ||= config.ssh.value(self);       end
+      def dump_file; @dump_file ||= config.dump_file.value(self); end
+      def source;    @source    ||= config.source.value(self);    end
+      def target;    @target    ||= config.target.value(self);    end
+
+      def copy_dump_cmd_args
+        @copy_dump_cmd_args ||= config.copy_dump_cmd_args.value(self)
+      end
+
+      def dump_cmds;    @dump_cmds    ||= config.dump_cmds.value(self);    end
+      def restore_cmds; @restore_cmds ||= config.restore_cmds.value(self); end
+
+      def source_dump_file; self.source.dump_file; end
+      def target_dump_file; self.target.dump_file; end
+
+      def source_hash; self.source.to_hash; end
+      def target_hash; self.target.to_hash; end
+
+      def ssh?
+        self.ssh && !self.ssh.empty?
+      end
+
+      def dump_cmd(&block);   config.dump_cmd(self, &block);    end
+      def restore_cmd(&block) config.restore_cmd(self, &block); end
+
+    end
+
+    module ClassMethods
+
+      def config(&block)
+        @config_block = block if !block.nil?
+        @config_block
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,0 +1,259 @@
+require 'assert'
+require 'dk-dumpdb/config'
+
+require 'dk-dumpdb/db'
+# require 'test/support/test_scripts'
+
+class Dk::Dumpdb::Config
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Config"
+    setup do
+      @script = FakeScript.new
+      @config_class = Dk::Dumpdb::Config
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      @config = @config_class.new
+    end
+    subject{ @config }
+
+    should have_readers :copy_dump_cmd_args, :dump_cmds, :restore_cmds
+    should have_imeths :ssh, :dump_file, :source, :target, :dump, :restore
+    should have_imeths :dump_cmd, :restore_cmd
+
+    should "default its values" do
+      assert_instance_of Ssh, subject.ssh
+      assert_equal '', subject.ssh.value(@script)
+
+      assert_instance_of DumpFile, subject.dump_file
+      assert_equal '', subject.dump_file.value(@script)
+
+      assert_instance_of SourceTargetDb, subject.source
+      val = subject.source.value(@script)
+      assert_instance_of Dk::Dumpdb::Db, val
+      exp = Dk::Dumpdb::Db.new(@script.dump_file, {})
+      assert_equal exp, val
+
+      assert_instance_of SourceTargetDb, subject.target
+      val = subject.target.value(@script)
+      assert_instance_of Dk::Dumpdb::Db, val
+      exp = Dk::Dumpdb::Db.new(@script.dump_file, {})
+      assert_equal exp, val
+
+      assert_instance_of CopyDumpCmdArgs, subject.copy_dump_cmd_args
+
+      assert_instance_of CmdList, subject.dump_cmds
+      assert_equal [], subject.dump_cmds.value(@script)
+
+      assert_instance_of CmdList, subject.restore_cmds
+      assert_equal [], subject.restore_cmds.value(@script)
+    end
+
+    should "allow setting new values" do
+      value = Factory.string
+      subject.ssh{ value }
+      assert_equal value, subject.ssh.value(@script)
+
+      subject.dump_file{ value }
+      assert_equal value, subject.dump_file.value(@script)
+
+      subject.source do
+        { 'pw' => value }
+      end
+      val = subject.source.value(@script)
+      exp = Dk::Dumpdb::Db.new(@script.dump_file, { 'pw' => value })
+      assert_equal exp, val
+
+      subject.target do
+        { 'pw' => value }
+      end
+      val = subject.target.value(@script)
+      exp = Dk::Dumpdb::Db.new(@script.dump_file, { 'pw' => value })
+      assert_equal exp, val
+    end
+
+    should "append dump/restore cmds" do
+      subject.dump{ Factory.string }
+      assert_equal 1, subject.dump_cmds.value(@script).size
+      assert_instance_of DumpCmd, subject.dump_cmds.first
+
+      subject.restore{ Factory.string }
+      assert_equal 1, subject.restore_cmds.value(@script).size
+      assert_instance_of RestoreCmd, subject.restore_cmds.first
+    end
+
+    should "build dump/restore cmd strs" do
+      cmd_str = "#{Factory.string}; pw: `:pw`"
+
+      exp = DumpCmd.new(proc{ cmd_str }).value(@script)
+      assert_equal exp, subject.dump_cmd(@script){ cmd_str }
+
+      exp = RestoreCmd.new(proc{ cmd_str }).value(@script)
+      assert_equal exp, subject.restore_cmd(@script){ cmd_str }
+    end
+
+  end
+
+  class ValueTests < UnitTests
+    desc "Value"
+    setup do
+      @setting = Value.new
+    end
+    subject{ @setting }
+
+    should have_readers :proc
+    should have_imeths :value
+
+    should "know its proc" do
+      assert_kind_of ::Proc, subject.proc
+      assert_nil subject.proc.call
+    end
+
+    should "instance eval its proc in the scope of a script to return a value" do
+      setting = Value.new(Proc.new{ "something: #{dump_file}" })
+      assert_equal "something: #{@script.dump_file}", setting.value(@script)
+    end
+
+  end
+
+  class SshTests < UnitTests
+    desc "Ssh"
+
+    should "be a Value" do
+      assert_true Ssh < Value
+    end
+
+  end
+
+  class DumpFileTests < UnitTests
+    desc "DumpFile"
+
+    should "be a Value" do
+      assert_true DumpFile < Value
+    end
+
+  end
+
+  class SourceTargetDbTests < UnitTests
+    desc "SourceTargetDb"
+
+    should "be a Value" do
+      assert_true SourceTargetDb < Value
+    end
+
+    should "have a Db value built from a hash" do
+      db_hash = { 'host' => Factory.string }
+      db = SourceTargetDb.new(db_hash).value(@script)
+      assert_instance_of Dk::Dumpdb::Db, db
+
+      assert_equal db_hash['host'], db.host
+      assert_includes @script.dump_file, db.to_hash[:dump_file]
+    end
+
+  end
+
+  class CopyDumpCmdArgsTests < UnitTests
+    desc "CopyDumpCmdArgs"
+
+    should "be a Value" do
+      assert_true CopyDumpCmdArgs < Value
+    end
+
+    should "know its value" do
+      exp = "#{@script.source_dump_file} #{@script.target_dump_file}"
+      assert_equal exp, CopyDumpCmdArgs.new.value(@script)
+    end
+
+  end
+
+  class CmdTests < UnitTests
+    desc "Cmd"
+
+    should "be a Value" do
+      assert_true Cmd < Value
+    end
+
+    should "eval and apply any placeholders to the cmd string" do
+      cmd_str = Proc.new{ "dump file: `#{dump_file}`; pw: `:pw`" }
+
+      exp = "dump file: `#{@script.dump_file}`; pw: `#{@script.source_hash['pw']}`"
+      assert_equal exp, Cmd.new(cmd_str).value(@script, @script.source_hash)
+    end
+
+  end
+
+  class DumpCmdTests < UnitTests
+    desc "DumpCmd"
+
+    should "be a Cmd" do
+      assert_true DumpCmd < Cmd
+    end
+
+    should "eval and apply any source placeholders to the cmd string" do
+      cmd_str = Proc.new{ "dump file: `#{dump_file}`; pw: `:pw`" }
+
+      exp = "dump file: `#{@script.dump_file}`; pw: `#{@script.source_hash['pw']}`"
+      assert_equal exp, DumpCmd.new(cmd_str).value(@script)
+    end
+
+  end
+
+  class RestoreCmdTests < UnitTests
+    desc "RestoreCmd"
+
+    should "be a Cmd" do
+      assert_true RestoreCmd < Cmd
+    end
+
+    should "eval and apply any target placeholders to the cmd string" do
+      cmd_str = Proc.new{ "dump file: `#{dump_file}`; pw: `:pw`" }
+
+      exp = "dump file: `#{@script.dump_file}`; pw: `#{@script.target_hash['pw']}`"
+      assert_equal exp, RestoreCmd.new(cmd_str).value(@script)
+    end
+
+  end
+
+  class CmdListTests < UnitTests
+    desc "CmdList"
+    setup do
+      other_cmd = Factory.string
+      @cmds = [
+        Cmd.new(Proc.new{ "dump file: `#{dump_file}`; pw: `:pw`" }),
+        Cmd.new(Proc.new{ other_cmd })
+      ]
+    end
+
+    should "be an Array" do
+      assert_kind_of ::Array, CmdList.new
+    end
+
+    should "return the commands, eval'd and placeholders applied" do
+      exp = @cmds.map{ |c| c.value(@script, @script.source_hash) }
+      assert_equal exp, CmdList.new(@cmds).value(@script, @script.source_hash)
+    end
+
+  end
+
+  class FakeScript
+    attr_reader :dump_file, :source_dump_file, :target_dump_file
+    attr_reader :source_hash, :target_hash
+
+    def initialize
+      @dump_file        = Factory.string
+      @source_dump_file = File.join(Factory.path, @dump_file)
+      @target_dump_file = File.join(Factory.path, @dump_file)
+      @source_hash      = { 'pw' => Factory.string }
+      @target_hash      = { 'pw' => Factory.string }
+    end
+  end
+
+end

--- a/test/unit/db_tests.rb
+++ b/test/unit/db_tests.rb
@@ -1,0 +1,103 @@
+require 'assert'
+require 'dk-dumpdb/db'
+
+class Dk::Dumpdb::Db
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Db"
+    setup do
+      @db_class = Dk::Dumpdb::Db
+    end
+    subject{ @db_class }
+
+    should "know its default value" do
+      assert_equal '', DEFAULT_VALUE
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @dump_file_name = Factory.file_name
+      @host           = Factory.string
+      @port           = Factory.integer
+      @user           = Factory.string
+      @pw             = Factory.string
+      @db_name        = Factory.string
+      @output_root    = Factory.dir_path
+      @custom_value   = Factory.string
+
+      @current_time = Factory.time
+      Assert.stub(Time, :now){ @current_time }
+
+      @db = @db_class.new(@dump_file_name, {
+        :host         => @host,
+        :port         => @port,
+        :user         => @user,
+        :pw           => @pw,
+        :db           => @db_name,
+        :output_root  => @output_root,
+        :custom_value => @custom_value
+      })
+    end
+    subject{ @db }
+
+    should have_imeths :host, :port, :user, :pw, :db
+    should have_imeths :output_root, :output_dir, :dump_file
+    should have_imeths :to_hash
+
+    should "know its attributes" do
+      assert_equal @host,        subject.host
+      assert_equal @port,        subject.port
+      assert_equal @user,        subject.user
+      assert_equal @pw,          subject.pw
+      assert_equal @db_name,     subject.db
+      assert_equal @output_root, subject.output_root
+
+      exp = File.join(@output_root, "#{@host}__#{@db_name}__#{@current_time.to_f}")
+      assert_equal exp, subject.output_dir
+
+      exp = File.join(subject.output_dir, @dump_file_name)
+      assert_equal exp, subject.dump_file
+    end
+
+    should "allow custom attributes" do
+      assert_true subject.respond_to?(:custom_value)
+      assert_equal @custom_value, subject.custom_value
+    end
+
+    should "default its attributes" do
+      db = @db_class.new
+
+      assert_equal DEFAULT_VALUE, db.host
+      assert_equal DEFAULT_VALUE, db.port
+      assert_equal DEFAULT_VALUE, db.user
+      assert_equal DEFAULT_VALUE, db.pw
+      assert_equal DEFAULT_VALUE, db.db
+      assert_equal DEFAULT_VALUE, db.output_root
+      assert_equal @current_time.to_f.to_s, db.output_dir
+
+      exp = File.join(db.output_dir, 'dump.output')
+      assert_equal exp, db.dump_file
+    end
+
+    should "know if it is equal to another db" do
+      equal_db = @db_class.new(@dump_file_name, {
+        :host         => @host,
+        :port         => @port,
+        :user         => @user,
+        :pw           => @pw,
+        :db           => @db_name,
+        :output_root  => @output_root,
+        :custom_value => @custom_value
+      })
+      assert_equal subject, equal_db
+
+      not_equal_db = @db_class.new(@dump_file_name, {})
+      assert_not_equal subject, not_equal_db
+    end
+
+  end
+
+end

--- a/test/unit/script_tests.rb
+++ b/test/unit/script_tests.rb
@@ -1,0 +1,128 @@
+require 'assert'
+require 'dk-dumpdb/script'
+
+require 'much-plugin'
+require 'dk-dumpdb/config'
+
+module Dk::Dumpdb::Script
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Script"
+    subject{ Dk::Dumpdb::Script }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    desc "mixin"
+    setup do
+      @config_proc = config_proc = Proc.new do
+        ssh{ "user@host" }
+
+        dump_file{ "dump.bz2" }
+
+        source do
+          { :user        => 'admin',
+            :pw          => 'secret',
+            :db          => 'myapp_db',
+            :output_root => '/some/source/dir'
+          }
+        end
+        target do
+          { :host        => 'localhost',
+            :user        => 'admin',
+            :db          => 'myapp_db',
+            :output_root => '/some/target/dir'
+          }
+        end
+
+        dump{ "mysqldump -u :user -p\":pw\" :db | bzip2 > :dump_file" }
+        restore{ "bunzip2 -c :dump_file | mysql -u :user -p\":pw\" :db" }
+      end
+      @script_class = Class.new do
+        include Dk::Dumpdb::Script
+        config &config_proc
+      end
+    end
+    subject{ @script_class }
+
+    should have_imeths :config
+
+    should "store the config proc to eval when initialized" do
+      assert_equal @config_proc, subject.config
+    end
+  end
+
+  class InitTests < MixinTests
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      @script = @script_class.new
+    end
+    subject{ @script }
+
+    should have_imeths :config
+    should have_imeths :ssh, :dump_file, :source, :target, :copy_dump_cmd_args
+    should have_imeths :dump_cmds, :restore_cmds
+    should have_imeths :source_dump_file, :target_dump_file
+    should have_imeths :source_hash, :target_hash
+    should have_imeths :ssh?
+    should have_imeths :dump_cmd, :restore_cmd
+
+    should "know its config" do
+      assert_instance_of Dk::Dumpdb::Config, subject.config
+    end
+
+    should "know its config values" do
+      c = subject.config
+      assert_equal c.ssh.value(subject),       subject.ssh
+      assert_equal c.dump_file.value(subject), subject.dump_file
+      assert_equal c.source.value(subject),    subject.source
+      assert_equal c.target.value(subject),    subject.target
+
+      assert_equal c.copy_dump_cmd_args.value(subject), subject.copy_dump_cmd_args
+
+      assert_equal c.dump_cmds.value(subject),    subject.dump_cmds
+      assert_equal c.restore_cmds.value(subject), subject.restore_cmds
+    end
+
+    should "demeter its source/target" do
+      assert_equal subject.source.dump_file, subject.source_dump_file
+      assert_equal subject.target.dump_file, subject.target_dump_file
+      assert_equal subject.source.to_hash,   subject.source_hash
+      assert_equal subject.target.to_hash,   subject.target_hash
+    end
+
+    should "know if it should use ssh or not" do
+      assert_true subject.ssh?
+
+      none = Class.new{ include Dk::Dumpdb::Script }
+      assert_false none.new.ssh?
+
+      empty = Class.new do
+        include Dk::Dumpdb::Script
+        config do
+          ssh{ '' }
+        end
+      end
+      assert_false empty.new.ssh?
+    end
+
+    should "build dump/restore cmd strs" do
+      cmd_str = Factory.string
+
+      exp = subject.config.dump_cmd(subject, &proc{ cmd_str })
+      assert_equal exp, subject.dump_cmd(&proc{ cmd_str })
+
+      exp = subject.config.restore_cmd(subject, &proc{ cmd_str })
+      assert_equal exp, subject.restore_cmd(&proc{ cmd_str })
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is the first pass Script mixin.  It adds the same DSL/API
as the Dumpdb mixin with a few exceptions.

Unlike Dumpdb, this uses a config instance to store the DSL values.
This is to avoid messing with global state and to make the DSL
logic more easily tested.  Also, unlike Dumpdb, scripts demeter
their source/targets.  Finally, unlike Dumpdb, scripts track their
copy dump cmd _args_, not the full cmd strings.  This is b/c
we are going to let the (coming) Dk tasks choose how to run
the copy dump cmd based on the script's `ssh?` value.  This allows
reuse of all the Dk ssh logic and cmd building so we don't have to
reimplement it.

Also, unlike Dumpdb, there are no callbacks or run logic in
scripts.  Running and callbacks will be handled by Dk tasks.

This brings in the Db logic directly from Dumpdb - it is being
used almost exactly as-is.  The only difference as these db objs
know if they are equal to another db or not (for testing).

One other change from Dumpdb, the "settings" from Dumpdb have been
renamed as Config "values".  They are now organized under the
Config obj but this is just a naming organization change.  They
function just like in Dumpdb with the exception of the copy dump
cmd args value which is mentioned above.

This is the first part of porting Dumpdb logic here.  In a coming
effort, I'll add the task mixin for defining tasks to run scripts.

@jcredding ready for review.
