### PR TITLE
basic task mixin and internal task framework

### DIFF
--- a/lib/dk-dumpdb.rb
+++ b/lib/dk-dumpdb.rb
@@ -1,2 +1,3 @@
 require 'dk-dumpdb/version'
 require 'dk-dumpdb/script'
+require 'dk-dumpdb/task'

--- a/lib/dk-dumpdb/task.rb
+++ b/lib/dk-dumpdb/task.rb
@@ -1,0 +1,58 @@
+require 'dk/task'
+require 'much-plugin'
+require 'dk-dumpdb/task/copy_dump'
+require 'dk-dumpdb/task/dump'
+require 'dk-dumpdb/task/restore'
+require 'dk-dumpdb/task/setup'
+require 'dk-dumpdb/task/teardown'
+
+module Dk::Dumpdb
+
+  module Task
+    include MuchPlugin
+
+    plugin_included do
+      include Dk::Task
+      include InstanceMethods
+      extend ClassMethods
+
+    end
+
+    module InstanceMethods
+
+      def run!
+        # script = self.class.script_class.new
+
+        # run_task Setup,      'script' => script
+        # begin
+        #   run_task Dump,     'script' => script
+        #   run_task CopyDump, 'script' => script
+        #   run_task Restore,  'script' => script
+        # ensure
+        #   run_task Teardown, 'script' => script
+        # end
+      end
+
+    end
+
+    module ClassMethods
+
+      # def script_class(value = nil)
+      #   @script_class = value if !value.nil?
+      #   @script_class
+      # end
+
+    end
+
+    module TestHelpers
+      include MuchPlugin
+
+      plugin_included do
+        include Dk::Task::TestHelpers
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/task/copy_dump.rb
+++ b/lib/dk-dumpdb/task/copy_dump.rb
@@ -1,0 +1,16 @@
+require 'dk-dumpdb/task/internal_task'
+
+module Dk::Dumpdb::Task
+
+  class CopyDump
+    include Dk::Dumpdb::Task::InternalTask
+
+    desc "(dk-dumpdb) copy the given script's dump file from source to target"
+
+    def run!
+      # TODO
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/task/dump.rb
+++ b/lib/dk-dumpdb/task/dump.rb
@@ -1,0 +1,16 @@
+require 'dk-dumpdb/task/internal_task'
+
+module Dk::Dumpdb::Task
+
+  class Dump
+    include Dk::Dumpdb::Task::InternalTask
+
+    desc "(dk-dumpdb) run the given script's dump cmds"
+
+    def run!
+      # TODO
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/task/internal_task.rb
+++ b/lib/dk-dumpdb/task/internal_task.rb
@@ -1,0 +1,36 @@
+require 'dk/task'
+require 'much-plugin'
+
+module Dk::Dumpdb;end
+module Dk::Dumpdb::Task
+
+  module InternalTask
+    include MuchPlugin
+
+    plugin_included do
+      include Dk::Task
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def source_cmd!(cmd_str)
+        if params['script'].ssh?
+          ssh!(cmd_str, :hosts => params['script'].ssh)
+        else
+          cmd!(cmd_str)
+        end
+      end
+
+      def target_cmd!(cmd_str)
+        cmd!(cmd_str)
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/task/restore.rb
+++ b/lib/dk-dumpdb/task/restore.rb
@@ -1,0 +1,16 @@
+require 'dk-dumpdb/task/internal_task'
+
+module Dk::Dumpdb::Task
+
+  class Restore
+    include Dk::Dumpdb::Task::InternalTask
+
+    desc "(dk-dumpdb) run the given script's restore cmds"
+
+    def run!
+      # TODO
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/task/setup.rb
+++ b/lib/dk-dumpdb/task/setup.rb
@@ -1,0 +1,18 @@
+require 'dk-dumpdb/task/internal_task'
+
+module Dk::Dumpdb::Task
+
+  class Setup
+    include Dk::Dumpdb::Task::InternalTask
+
+    desc "(dk-dumpdb) setup a script run"
+
+    def run!
+      # TODO
+      # source_cmd!(params['script'].dump_cmd{ "mkdir -p #{source.output_dir}" })
+      # target_cmd!(params['script'].restore_cmd{ "mkdir -p #{target.output_dir}" })
+    end
+
+  end
+
+end

--- a/lib/dk-dumpdb/task/teardown.rb
+++ b/lib/dk-dumpdb/task/teardown.rb
@@ -1,0 +1,18 @@
+require 'dk-dumpdb/task/internal_task'
+
+module Dk::Dumpdb::Task
+
+  class Teardown
+    include Dk::Dumpdb::Task::InternalTask
+
+    desc "(dk-dumpdb) teardown a script run"
+
+    def run!
+      # TODO
+      # source_cmd!(params['script'].dump_cmd{ "rm -rf #{source.output_dir}" })
+      # target_cmd!(params['script'].restore_cmd{ "rm -rf #{target.output_dir}" })
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,6 +1,18 @@
 require 'assert/factory'
+require 'dk-dumpdb/script'
 
 module Factory
   extend Assert::Factory
+
+  def self.script_class(&config_proc)
+    Class.new do
+      include Dk::Dumpdb::Script
+      config &config_proc
+    end
+  end
+
+  def self.script(script_class = nil, &config_proc)
+    (script_class || self.script_class(&config_proc)).new
+  end
 
 end

--- a/test/support/task/internal_task.rb
+++ b/test/support/task/internal_task.rb
@@ -1,0 +1,27 @@
+require 'dk/task'
+require 'much-plugin'
+require 'dk-dumpdb/task/internal_task'
+
+module Dk::Dumpdb::Task::InternalTask
+
+  module TestHelpers
+    include MuchPlugin
+
+    plugin_included do
+      include Dk::Task::TestHelpers
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      def set_dk_dumpdb_script_param(*args, &block)
+        @params ||= {}
+        @params['script'] = Factory.script(*args, &block)
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/task/copy_dump_tests.rb
+++ b/test/unit/task/copy_dump_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'dk-dumpdb/task/copy_dump'
+
+require 'test/support/task/internal_task'
+
+class Dk::Dumpdb::Task::CopyDump
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task::CopyDump"
+    setup do
+      @task_class = Dk::Dumpdb::Task::CopyDump
+    end
+    subject{ @task_class}
+
+    should "be an internal task" do
+      assert_includes Dk::Dumpdb::Task::InternalTask, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-dumpdb) copy the given script's dump file from source to target"
+      assert_equal exp, subject.description
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::Dumpdb::Task::InternalTask::TestHelpers
+
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      set_dk_dumpdb_script_param
+      @runner = test_runner(@task_class, :params => @params)
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "do something"
+
+  end
+
+end

--- a/test/unit/task/dump_tests.rb
+++ b/test/unit/task/dump_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'dk-dumpdb/task/dump'
+
+require 'test/support/task/internal_task'
+
+class Dk::Dumpdb::Task::Dump
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task::Dump"
+    setup do
+      @task_class = Dk::Dumpdb::Task::Dump
+    end
+    subject{ @task_class}
+
+    should "be an internal task" do
+      assert_includes Dk::Dumpdb::Task::InternalTask, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-dumpdb) run the given script's dump cmds"
+      assert_equal exp, subject.description
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::Dumpdb::Task::InternalTask::TestHelpers
+
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      set_dk_dumpdb_script_param
+      @runner = test_runner(@task_class, :params => @params)
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "do something"
+
+  end
+
+end

--- a/test/unit/task/internal_task_tests.rb
+++ b/test/unit/task/internal_task_tests.rb
@@ -1,0 +1,84 @@
+require 'assert'
+require 'dk-dumpdb/task/internal_task'
+
+require 'dk'
+require 'dk/task'
+require 'much-plugin'
+
+module Dk::Dumpdb::Task::InternalTask
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task::InternalTask"
+    setup do
+      @module = Dk::Dumpdb::Task::InternalTask
+    end
+    subject{ @module }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    desc "mixin"
+    setup do
+      @task_class = Class.new do
+        include Dk::Dumpdb::Task::InternalTask
+        def run!
+          source_cmd! "a source cmd"
+          target_cmd! "a target cmd"
+        end
+      end
+    end
+    subject{ @task_class }
+
+    should "be a Dk task" do
+      assert_includes Dk::Task, subject
+    end
+
+  end
+
+  class InitTests < MixinTests
+    include Dk::Task::TestHelpers
+
+    desc "when init"
+    setup do
+      @params = {}
+    end
+
+    should "run source/target cmds as local Dk cmds if not an ssh script" do
+      @params['script'] = Factory.script
+      runner = test_runner(@task_class, :params => @params)
+      task   = runner.task
+
+      runner.run
+      assert_equal 2, runner.runs.size
+
+      source_cmd, target_cmd = runner.runs
+      assert_false source_cmd.ssh?
+      assert_false target_cmd.ssh?
+      assert_equal "a source cmd", source_cmd.cmd_str
+      assert_equal "a target cmd", target_cmd.cmd_str
+    end
+
+    should "run source cmds as remote Dk cmds if an ssh script" do
+      @params['script'] = Factory.script{ ssh{ "hostname" } }
+      runner = test_runner(@task_class, :params => @params)
+      task   = runner.task
+
+      runner.run
+      assert_equal 2, runner.runs.size
+
+      source_ssh, target_cmd = runner.runs
+      assert_true  source_ssh.ssh?
+      assert_false target_cmd.ssh?
+      assert_equal "a source cmd", source_ssh.cmd_str
+      assert_equal "a target cmd", target_cmd.cmd_str
+
+      assert_equal [@params['script'].ssh], source_ssh.cmd_opts[:hosts]
+    end
+
+  end
+
+end

--- a/test/unit/task/restore_tests.rb
+++ b/test/unit/task/restore_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'dk-dumpdb/task/restore'
+
+require 'test/support/task/internal_task'
+
+class Dk::Dumpdb::Task::Restore
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task::Restore"
+    setup do
+      @task_class = Dk::Dumpdb::Task::Restore
+    end
+    subject{ @task_class}
+
+    should "be an internal task" do
+      assert_includes Dk::Dumpdb::Task::InternalTask, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-dumpdb) run the given script's restore cmds"
+      assert_equal exp, subject.description
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::Dumpdb::Task::InternalTask::TestHelpers
+
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      set_dk_dumpdb_script_param
+      @runner = test_runner(@task_class, :params => @params)
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "do something"
+
+  end
+
+end

--- a/test/unit/task/setup_tests.rb
+++ b/test/unit/task/setup_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'dk-dumpdb/task/setup'
+
+require 'test/support/task/internal_task'
+
+class Dk::Dumpdb::Task::Setup
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task::Setup"
+    setup do
+      @task_class = Dk::Dumpdb::Task::Setup
+    end
+    subject{ @task_class}
+
+    should "be an internal task" do
+      assert_includes Dk::Dumpdb::Task::InternalTask, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-dumpdb) setup a script run"
+      assert_equal exp, subject.description
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::Dumpdb::Task::InternalTask::TestHelpers
+
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      set_dk_dumpdb_script_param
+      @runner = test_runner(@task_class, :params => @params)
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "do something"
+
+  end
+
+end

--- a/test/unit/task/teardown_tests.rb
+++ b/test/unit/task/teardown_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'dk-dumpdb/task/teardown'
+
+require 'test/support/task/internal_task'
+
+class Dk::Dumpdb::Task::Teardown
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task::Teardown"
+    setup do
+      @task_class = Dk::Dumpdb::Task::Teardown
+    end
+    subject{ @task_class}
+
+    should "be an internal task" do
+      assert_includes Dk::Dumpdb::Task::InternalTask, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-dumpdb) teardown a script run"
+      assert_equal exp, subject.description
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Dk::Dumpdb::Task::InternalTask::TestHelpers
+
+    desc "when init"
+    setup do
+      now = Factory.time
+      Assert.stub(Time, :now){ now }
+
+      set_dk_dumpdb_script_param
+      @runner = test_runner(@task_class, :params => @params)
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "do something"
+
+  end
+
+end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -1,0 +1,76 @@
+require 'assert'
+require 'dk-dumpdb/task'
+
+require 'dk/task'
+require 'much-plugin'
+require 'dk-dumpdb/task/copy_dump'
+require 'dk-dumpdb/task/dump'
+require 'dk-dumpdb/task/restore'
+require 'dk-dumpdb/task/setup'
+require 'dk-dumpdb/task/teardown'
+
+module Dk::Dumpdb::Task
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb::Task"
+    subject{ Dk::Dumpdb::Task }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    desc "mixin"
+    setup do
+      @task_class = Class.new do
+        include Dk::Dumpdb::Task
+
+      end
+    end
+    subject{ @task_class }
+
+    should "be a Dk task" do
+      assert_includes Dk::Task, subject
+    end
+
+  end
+
+  class InitTests < MixinTests
+    include Dk::Task::TestHelpers
+
+    desc "when init"
+    setup do
+      @runner = test_runner(@task_class)
+      @task   = @runner.task
+    end
+    subject{ @task }
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "do something"
+
+  end
+
+  class TestHelpersTets < UnitTests
+    desc "TestHelpers"
+    setup do
+      @context_class = Class.new{ include Dk::Dumpdb::Task::TestHelpers }
+      @context = @context_class.new
+    end
+    subject{ @context }
+
+    should "include Dk task test hepers" do
+      assert_includes Dk::Task::TestHelpers, @context_class
+    end
+
+  end
+
+end


### PR DESCRIPTION
This sets up the basic task mixin and the framework for the
internal tasks that script tasks will run.  I'm choosing to model
each "phase" of a script as a separate task so that user's can
bind callbacks in their dk configure blocks.  This removes the
need for dk-dumpdb to manage callbacks and allows the user to just
use what Dk makes available.

This doesn't actually implement any of the tasks.  The main mixin
`run!` method and the setup/teardown tasks have some pseudo-code
commented out for reference.  In a coming effort, I'll implement
everything.

This does go head and implement/test an InternalTask mixin.  This
is used by the internal tasks to provide some common logic:
specifically the logic for whether to run source cmds using ssh
or not.  This allows the tasks to just concentrate on whether
their cmds affect the source of the target and not on the
repetitive details of managing source cmds based on the script.

@jcredding ready for review.
