### PR TITLE
implement the Setup and Teardown tasks

### DIFF
--- a/lib/dk-dumpdb/task/setup.rb
+++ b/lib/dk-dumpdb/task/setup.rb
@@ -8,9 +8,8 @@ module Dk::Dumpdb::Task
     desc "(dk-dumpdb) setup a script run"
 
     def run!
-      # TODO
-      # source_cmd!(params['script'].dump_cmd{ "mkdir -p #{source.output_dir}" })
-      # target_cmd!(params['script'].restore_cmd{ "mkdir -p #{target.output_dir}" })
+      source_cmd!(params['script'].dump_cmd{ "mkdir -p #{source.output_dir}" })
+      target_cmd!(params['script'].restore_cmd{ "mkdir -p #{target.output_dir}" })
     end
 
   end

--- a/lib/dk-dumpdb/task/teardown.rb
+++ b/lib/dk-dumpdb/task/teardown.rb
@@ -8,9 +8,8 @@ module Dk::Dumpdb::Task
     desc "(dk-dumpdb) teardown a script run"
 
     def run!
-      # TODO
-      # source_cmd!(params['script'].dump_cmd{ "rm -rf #{source.output_dir}" })
-      # target_cmd!(params['script'].restore_cmd{ "rm -rf #{target.output_dir}" })
+      source_cmd!(params['script'].dump_cmd{ "rm -rf #{source.output_dir}" })
+      target_cmd!(params['script'].restore_cmd{ "rm -rf #{target.output_dir}" })
     end
 
   end

--- a/test/unit/task/setup_tests.rb
+++ b/test/unit/task/setup_tests.rb
@@ -42,8 +42,18 @@ class Dk::Dumpdb::Task::Setup
     setup do
       @runner.run
     end
+    subject{ @runner }
 
-    should "do something"
+    should "run 2 cmds" do
+      assert_equal 2, subject.runs.size
+      mkdir_src, mkdir_targ = subject.runs
+
+      exp = @params['script'].dump_cmd{ "mkdir -p #{source.output_dir}" }
+      assert_equal exp, mkdir_src.cmd_str
+
+      exp = @params['script'].restore_cmd{ "mkdir -p #{target.output_dir}" }
+      assert_equal exp, mkdir_targ.cmd_str
+    end
 
   end
 

--- a/test/unit/task/teardown_tests.rb
+++ b/test/unit/task/teardown_tests.rb
@@ -42,8 +42,18 @@ class Dk::Dumpdb::Task::Teardown
     setup do
       @runner.run
     end
+    subject{ @runner }
 
-    should "do something"
+    should "run 2 cmds" do
+      assert_equal 2, subject.runs.size
+      rmdir_src, rmdir_targ = subject.runs
+
+      exp = @params['script'].dump_cmd{ "rm -rf #{source.output_dir}" }
+      assert_equal exp, rmdir_src.cmd_str
+
+      exp = @params['script'].restore_cmd{ "rm -rf #{target.output_dir}" }
+      assert_equal exp, rmdir_targ.cmd_str
+    end
 
   end
 


### PR DESCRIPTION
These tasks ensure the source/target output dirs are made and then
removed.  This is copied form the Runner logic in dumpdb and is
part of bringing in the dumpdb logic here so it can be run using
Dk.

@jcredding ready for review
