### PR TITLE
implement the Dump, CopyDump and Restore tasks

### DIFF
--- a/lib/dk-dumpdb/task/copy_dump.rb
+++ b/lib/dk-dumpdb/task/copy_dump.rb
@@ -8,7 +8,7 @@ module Dk::Dumpdb::Task
     desc "(dk-dumpdb) copy the given script's dump file from source to target"
 
     def run!
-      # TODO
+      copy_cmd! params['script'].copy_dump_cmd_args
     end
 
   end

--- a/lib/dk-dumpdb/task/dump.rb
+++ b/lib/dk-dumpdb/task/dump.rb
@@ -8,7 +8,7 @@ module Dk::Dumpdb::Task
     desc "(dk-dumpdb) run the given script's dump cmds"
 
     def run!
-      # TODO
+      params['script'].dump_cmds.each{ |cmd_str| source_cmd!(cmd_str) }
     end
 
   end

--- a/lib/dk-dumpdb/task/internal_task.rb
+++ b/lib/dk-dumpdb/task/internal_task.rb
@@ -25,6 +25,15 @@ module Dk::Dumpdb::Task
         end
       end
 
+      def copy_cmd!(args)
+        if (s = params['script']).ssh?
+          cmd! "sftp #{@dk_runner.ssh_args} #{@dk_runner.host_ssh_args[s.ssh]} " \
+               "#{s.ssh}:#{args}"
+        else
+          cmd! "cp #{args}"
+        end
+      end
+
       def target_cmd!(cmd_str)
         cmd!(cmd_str)
       end

--- a/lib/dk-dumpdb/task/restore.rb
+++ b/lib/dk-dumpdb/task/restore.rb
@@ -8,7 +8,7 @@ module Dk::Dumpdb::Task
     desc "(dk-dumpdb) run the given script's restore cmds"
 
     def run!
-      # TODO
+      params['script'].restore_cmds.each{ |cmd_str| target_cmd!(cmd_str) }
     end
 
   end

--- a/test/unit/task/copy_dump_tests.rb
+++ b/test/unit/task/copy_dump_tests.rb
@@ -42,8 +42,15 @@ class Dk::Dumpdb::Task::CopyDump
     setup do
       @runner.run
     end
+    subject{ @runner }
 
-    should "do something"
+    should "run a cmd to copy the dump" do
+      assert_equal 1, subject.runs.size
+      cp_dump = subject.runs.first
+
+      exp = @params['script'].copy_dump_cmd_args
+      assert_match /#{exp}\Z/, cp_dump.cmd_str
+    end
 
   end
 

--- a/test/unit/task/dump_tests.rb
+++ b/test/unit/task/dump_tests.rb
@@ -31,7 +31,12 @@ class Dk::Dumpdb::Task::Dump
       now = Factory.time
       Assert.stub(Time, :now){ now }
 
-      set_dk_dumpdb_script_param
+      @dump_cmds = dump_cmds = Factory.integer(3).times.map{ Factory.string }
+      set_dk_dumpdb_script_param do
+        dump_cmds.each do |cmd_str|
+          dump{ cmd_str }
+        end
+      end
       @runner = test_runner(@task_class, :params => @params)
     end
 
@@ -42,8 +47,11 @@ class Dk::Dumpdb::Task::Dump
     setup do
       @runner.run
     end
+    subject{ @runner }
 
-    should "do something"
+    should "run all dump cmds" do
+      assert_equal @dump_cmds, subject.runs.map(&:cmd_str)
+    end
 
   end
 

--- a/test/unit/task/internal_task_tests.rb
+++ b/test/unit/task/internal_task_tests.rb
@@ -25,8 +25,10 @@ module Dk::Dumpdb::Task::InternalTask
     setup do
       @task_class = Class.new do
         include Dk::Dumpdb::Task::InternalTask
+        attr_writer :cp_cmd_args
         def run!
           source_cmd! "a source cmd"
+          copy_cmd! @cp_cmd_args
           target_cmd! "a target cmd"
         end
       end
@@ -44,39 +46,60 @@ module Dk::Dumpdb::Task::InternalTask
 
     desc "when init"
     setup do
-      @params = {}
+      @cp_args = "#{Factory.file_path} #{Factory.file_path}"
+      @params  = {}
     end
 
-    should "run source/target cmds as local Dk cmds if not an ssh script" do
+    should "run source/target/copy cmds as local Dk cmds if not an ssh script" do
       @params['script'] = Factory.script
       runner = test_runner(@task_class, :params => @params)
       task   = runner.task
 
+      task.cp_cmd_args = @cp_args
       runner.run
-      assert_equal 2, runner.runs.size
+      assert_equal 3, runner.runs.size
 
-      source_cmd, target_cmd = runner.runs
+      source_cmd, copy_cmd, target_cmd = runner.runs
       assert_false source_cmd.ssh?
       assert_false target_cmd.ssh?
+      assert_false copy_cmd.ssh?
+
       assert_equal "a source cmd", source_cmd.cmd_str
       assert_equal "a target cmd", target_cmd.cmd_str
+
+      exp = "cp #{@cp_args}"
+      assert_equal exp, copy_cmd.cmd_str
     end
 
-    should "run source cmds as remote Dk cmds if an ssh script" do
+    should "run source/copy cmds as remote Dk cmds if an ssh script" do
       @params['script'] = Factory.script{ ssh{ "hostname" } }
-      runner = test_runner(@task_class, :params => @params)
+      @ssh_args         = Factory.string
+      @host_ssh_args    = { "hostname" => Factory.string }
+
+      runner = test_runner(@task_class, {
+        :params        => @params,
+        :ssh_args      => @ssh_args,
+        :host_ssh_args => @host_ssh_args
+      })
       task   = runner.task
 
+      task.cp_cmd_args = @cp_args
       runner.run
-      assert_equal 2, runner.runs.size
+      assert_equal 3, runner.runs.size
 
-      source_ssh, target_cmd = runner.runs
+      source_ssh, copy_cmd, target_cmd = runner.runs
       assert_true  source_ssh.ssh?
       assert_false target_cmd.ssh?
+      assert_false copy_cmd.ssh?
+
+      assert_equal [@params['script'].ssh], source_ssh.cmd_opts[:hosts]
+
       assert_equal "a source cmd", source_ssh.cmd_str
       assert_equal "a target cmd", target_cmd.cmd_str
 
-      assert_equal [@params['script'].ssh], source_ssh.cmd_opts[:hosts]
+      exp = "sftp #{@ssh_args} #{@host_ssh_args[@params['script'].ssh]} " \
+            "#{@params['script'].ssh}:#{@cp_args}"
+      assert_equal exp, copy_cmd.cmd_str
     end
 
   end

--- a/test/unit/task/restore_tests.rb
+++ b/test/unit/task/restore_tests.rb
@@ -31,7 +31,12 @@ class Dk::Dumpdb::Task::Restore
       now = Factory.time
       Assert.stub(Time, :now){ now }
 
-      set_dk_dumpdb_script_param
+      @restore_cmds = restore_cmds = Factory.integer(3).times.map{ Factory.string }
+      set_dk_dumpdb_script_param do
+        restore_cmds.each do |cmd_str|
+          restore{ cmd_str }
+        end
+      end
       @runner = test_runner(@task_class, :params => @params)
     end
 
@@ -42,8 +47,11 @@ class Dk::Dumpdb::Task::Restore
     setup do
       @runner.run
     end
+    subject{ @runner }
 
-    should "do something"
+    should "run all restore cmds" do
+      assert_equal @restore_cmds, subject.runs.map(&:cmd_str)
+    end
 
   end
 


### PR DESCRIPTION
These tasks run the dump cmds, copy the dump from source to target
and run the restore cmds respectively.  This also updates the
InternalTask helper to define a `copy_cmd!` method.  This method,
like `source_cmd!`, looks at the script's ssh settings and then
builds the appropriate copy cmd based on them.  This is used by
the CopyDump task to implement the copy.

All of this logic is copied form the Runner logic in dumpdb and is
part of bringing in the dumpdb logic here so it can be run using
Dk.

@jcredding ready for review.
