### PR TITLE
implement the Task mixin

### DIFF
--- a/lib/dk-dumpdb/task.rb
+++ b/lib/dk-dumpdb/task.rb
@@ -21,26 +21,26 @@ module Dk::Dumpdb
     module InstanceMethods
 
       def run!
-        # script = self.class.script_class.new
+        script = self.class.script_class.new
 
-        # run_task Setup,      'script' => script
-        # begin
-        #   run_task Dump,     'script' => script
-        #   run_task CopyDump, 'script' => script
-        #   run_task Restore,  'script' => script
-        # ensure
-        #   run_task Teardown, 'script' => script
-        # end
+        run_task Setup,      'script' => script
+        begin
+          run_task Dump,     'script' => script
+          run_task CopyDump, 'script' => script
+          run_task Restore,  'script' => script
+        ensure
+          run_task Teardown, 'script' => script
+        end
       end
 
     end
 
     module ClassMethods
 
-      # def script_class(value = nil)
-      #   @script_class = value if !value.nil?
-      #   @script_class
-      # end
+      def script_class(value = nil)
+        @script_class = value if !value.nil?
+        @script_class
+      end
 
     end
 

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -31,8 +31,19 @@ module Dk::Dumpdb::Task
     end
     subject{ @task_class }
 
+    should have_imeths :script_class
+
     should "be a Dk task" do
       assert_includes Dk::Task, subject
+    end
+
+    should "know its script class" do
+      assert_nil subject.script_class
+
+      value = Factory.string
+      subject.script_class value
+
+      assert_equal value, subject.script_class
     end
 
   end
@@ -52,10 +63,30 @@ module Dk::Dumpdb::Task
   class RunTests < InitTests
     desc "and run"
     setup do
+      @task_class.script_class Factory.script_class
+
+      @script = @task_class.script_class.new
+      Assert.stub(@task_class.script_class, :new){ @script }
+
       @runner.run
     end
+    subject{ @runner }
 
-    should "do something"
+    should "build an instance of its script class and run it" do
+      assert_equal 5, subject.runs.size
+
+      setup, dump, copydump, restore, teardown = subject.runs
+
+      assert_equal Setup,    setup.task_class
+      assert_equal Dump,     dump.task_class
+      assert_equal CopyDump, copydump.task_class
+      assert_equal Restore,  restore.task_class
+      assert_equal Teardown, teardown.task_class
+
+      subject.runs.each do |task_run|
+        assert_equal @script, task_run.params['script']
+      end
+    end
 
   end
 
@@ -67,7 +98,7 @@ module Dk::Dumpdb::Task
     end
     subject{ @context }
 
-    should "include Dk task test hepers" do
+    should "include Dk task test helpers" do
       assert_includes Dk::Task::TestHelpers, @context_class
     end
 


### PR DESCRIPTION
This is the macro task logic for building a script instance and
then running it using the subtasks.  This logic is based on the
runner logic in Dumpdb but modified for Dk task usage.  This is
part of getting the dumpdb logic to run as a Dk task.

@jcredding ready for review.
