### PR TITLE
auto-create a Task for each Script

### DIFF
--- a/lib/dk-dumpdb/script.rb
+++ b/lib/dk-dumpdb/script.rb
@@ -1,5 +1,6 @@
 require 'much-plugin'
 require 'dk-dumpdb/config'
+require 'dk-dumpdb/task'
 
 module Dk::Dumpdb
 
@@ -9,6 +10,11 @@ module Dk::Dumpdb
     plugin_included do
       include InstanceMethods
       extend ClassMethods
+
+      class Task
+        include Dk::Dumpdb::Task
+      end
+      Task.script_class self
 
     end
 

--- a/test/unit/script_tests.rb
+++ b/test/unit/script_tests.rb
@@ -3,6 +3,7 @@ require 'dk-dumpdb/script'
 
 require 'much-plugin'
 require 'dk-dumpdb/config'
+require 'dk-dumpdb/task'
 
 module Dk::Dumpdb::Script
 
@@ -55,6 +56,13 @@ module Dk::Dumpdb::Script
 
       subject.config(&@config_proc)
       assert_equal [@config_proc], subject.config_blocks
+    end
+
+    should "define a Task for the script class" do
+      task_class = @script_class::Task
+
+      assert_includes Dk::Dumpdb::Task, task_class
+      assert_equal @script_class, task_class.script_class
     end
 
   end


### PR DESCRIPTION
This updates the script mixin to, when included on a receiver,
create a Task subclass for the receiver and include the Task mixin
and set the receiver as the script class.  This does the crappy
boilerplate work on behalf of the user so they have tasks ready to
run for their scripts.

@jcredding ready for review.
