### PR TITLE
add a Script DSL method for setting the script's Task description

### DIFF
--- a/lib/dk-dumpdb/script.rb
+++ b/lib/dk-dumpdb/script.rb
@@ -65,6 +65,11 @@ module Dk::Dumpdb
         self.config_blocks << block if !block.nil?
       end
 
+      def task_description(value = nil)
+        self::Task.description(value)
+      end
+      alias_method :task_desc, :task_description
+
     end
 
   end

--- a/test/unit/script_tests.rb
+++ b/test/unit/script_tests.rb
@@ -49,7 +49,7 @@ module Dk::Dumpdb::Script
     end
     subject{ @script_class }
 
-    should have_imeths :config_blocks, :config
+    should have_imeths :config_blocks, :config, :task_description, :task_desc
 
     should "know its config blocks" do
       assert_empty subject.config_blocks
@@ -63,6 +63,21 @@ module Dk::Dumpdb::Script
 
       assert_includes Dk::Dumpdb::Task, task_class
       assert_equal @script_class, task_class.script_class
+    end
+
+    should "set a description on its Task" do
+      assert_nil subject.task_description
+      assert_nil subject.task_desc
+
+      exp = Factory.string
+      subject.task_description exp
+      assert_equal exp, subject.task_description
+      assert_equal exp, subject.task_desc
+
+      exp = Factory.string
+      subject.task_desc exp
+      assert_equal exp, subject.task_description
+      assert_equal exp, subject.task_desc
     end
 
   end


### PR DESCRIPTION
This allows the user to control the description given to the
auto-generated Task for each Script.  This is a side-effect of
auto-generating tasks: if the user had to create their own Tasks,
they could just choose their own descriptions then.

@jcredding ready for review.
