### PR TITLE
initialize Scripts with the Task params

### DIFF
--- a/lib/dk-dumpdb/script.rb
+++ b/lib/dk-dumpdb/script.rb
@@ -20,6 +20,12 @@ module Dk::Dumpdb
 
     module InstanceMethods
 
+      attr_reader :params
+
+      def initialize(task_params = nil)
+        @params = task_params || {}
+      end
+
       def config
         @config ||= Config.new.tap do |config|
           self.class.config_blocks.each do |config_block|

--- a/lib/dk-dumpdb/task.rb
+++ b/lib/dk-dumpdb/task.rb
@@ -21,7 +21,7 @@ module Dk::Dumpdb
     module InstanceMethods
 
       def run!
-        script = self.class.script_class.new
+        script = self.class.script_class.new(params)
 
         run_task Setup,      'script' => script
         begin

--- a/test/unit/script_tests.rb
+++ b/test/unit/script_tests.rb
@@ -93,6 +93,7 @@ module Dk::Dumpdb::Script
     end
     subject{ @script }
 
+    should have_readers :params
     should have_imeths :config
     should have_imeths :ssh, :dump_file, :source, :target, :copy_dump_cmd_args
     should have_imeths :dump_cmds, :restore_cmds
@@ -100,6 +101,15 @@ module Dk::Dumpdb::Script
     should have_imeths :source_hash, :target_hash
     should have_imeths :ssh?
     should have_imeths :dump_cmd, :restore_cmd
+
+    should "know its params" do
+      exp = {}
+      assert_equal exp, subject.params
+
+      params = { Factory.string => Factory.string }
+      script = @script_class.new(params)
+      assert_equal params, script.params
+    end
 
     should "know its config" do
       assert_instance_of Dk::Dumpdb::Config, subject.config

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -65,8 +65,12 @@ module Dk::Dumpdb::Task
     setup do
       @task_class.script_class Factory.script_class
 
+      @script_init_with = nil
       @script = @task_class.script_class.new
-      Assert.stub(@task_class.script_class, :new){ @script }
+      Assert.stub(@task_class.script_class, :new) do |*args|
+        @script_init_with = args
+        @script
+      end
 
       @runner.run
     end
@@ -82,6 +86,8 @@ module Dk::Dumpdb::Task
       assert_equal CopyDump, copydump.task_class
       assert_equal Restore,  restore.task_class
       assert_equal Teardown, teardown.task_class
+
+      assert_equal [@runner.params], @script_init_with
 
       subject.runs.each do |task_run|
         assert_equal @script, task_run.params['script']


### PR DESCRIPTION
This adds a `param` reader on Scripts and has Tasks create their
scripts passing in their params.  This makes the Task params
available in Script logic.  This allows you to have tasks that
set params that control Script behavior.

@jcredding ready for review.
