### PR TITLE
switch to using scp for the copy dump file cmd

### DIFF
--- a/lib/dk-dumpdb.rb
+++ b/lib/dk-dumpdb.rb
@@ -1,3 +1,9 @@
 require 'dk-dumpdb/version'
 require 'dk-dumpdb/script'
 require 'dk-dumpdb/task'
+
+module Dk::Dumpdb
+
+  SCP_ARGS_PARAM_NAME = 'dk-dumpdb_scp_args'
+
+end

--- a/lib/dk-dumpdb/task/internal_task.rb
+++ b/lib/dk-dumpdb/task/internal_task.rb
@@ -1,7 +1,7 @@
 require 'dk/task'
 require 'much-plugin'
+require 'dk-dumpdb'
 
-module Dk::Dumpdb;end
 module Dk::Dumpdb::Task
 
   module InternalTask
@@ -27,8 +27,7 @@ module Dk::Dumpdb::Task
 
       def copy_cmd!(args)
         if (s = params['script']).ssh?
-          cmd! "sftp #{@dk_runner.ssh_args} #{@dk_runner.host_ssh_args[s.ssh]} " \
-               "#{s.ssh}:#{args}"
+          cmd! "scp #{try_param(Dk::Dumpdb::SCP_ARGS_PARAM_NAME)} #{s.ssh}:#{args}"
         else
           cmd! "cp #{args}"
         end

--- a/test/unit/dk-dumpdb_tests.rb
+++ b/test/unit/dk-dumpdb_tests.rb
@@ -1,0 +1,16 @@
+require 'assert'
+
+module Dk::Dumpdb
+
+  class UnitTests < Assert::Context
+    desc "Dk::Dumpdb"
+    subject{ Dk::Dumpdb }
+
+    should "know its scp args param name" do
+      exp = "dk-dumpdb_scp_args"
+      assert_equal exp, subject::SCP_ARGS_PARAM_NAME
+    end
+
+  end
+
+end

--- a/test/unit/task/internal_task_tests.rb
+++ b/test/unit/task/internal_task_tests.rb
@@ -4,6 +4,7 @@ require 'dk-dumpdb/task/internal_task'
 require 'dk'
 require 'dk/task'
 require 'much-plugin'
+require 'dk-dumpdb'
 
 module Dk::Dumpdb::Task::InternalTask
 
@@ -73,14 +74,12 @@ module Dk::Dumpdb::Task::InternalTask
 
     should "run source/copy cmds as remote Dk cmds if an ssh script" do
       @params['script'] = Factory.script{ ssh{ "hostname" } }
-      @ssh_args         = Factory.string
-      @host_ssh_args    = { "hostname" => Factory.string }
 
-      runner = test_runner(@task_class, {
-        :params        => @params,
-        :ssh_args      => @ssh_args,
-        :host_ssh_args => @host_ssh_args
-      })
+      if Factory.boolean
+        @params[Dk::Dumpdb::SCP_ARGS_PARAM_NAME] = Factory.string
+      end
+
+      runner = test_runner(@task_class, :params => @params)
       task   = runner.task
 
       task.cp_cmd_args = @cp_args
@@ -97,7 +96,7 @@ module Dk::Dumpdb::Task::InternalTask
       assert_equal "a source cmd", source_ssh.cmd_str
       assert_equal "a target cmd", target_cmd.cmd_str
 
-      exp = "sftp #{@ssh_args} #{@host_ssh_args[@params['script'].ssh]} " \
+      exp = "scp #{@params[Dk::Dumpdb::SCP_ARGS_PARAM_NAME]} " \
             "#{@params['script'].ssh}:#{@cp_args}"
       assert_equal exp, copy_cmd.cmd_str
     end


### PR DESCRIPTION
This is apparently faster than sftp but less feature-ful.  We
don't need a bunch of features for the copy so switch to get some
extra speed in copying.

This also switches off of using Dk's configured ssh args.  This
was a bug with the previous sftp implementation and is also an
issue with this scp implementation. The ssh args and scp (or sftp)
args aren't common so we can't blindly rely on them.  Really the
only "common" args are the `-o *` options. This switches to looking
for optional args in a named param so that the scp args can be
distinct from the ssh args.

@jcredding ready for review.
